### PR TITLE
Updating the import orders to be consistent.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,17 +22,21 @@
         "allowModules": ["colors"]
       }
     ],
-    "sort-class-members/sort-class-members": [2, {
-      "accessorPairPositioning": "getThenSet",
-      "order": [
-        { "type": "[static-properties]", "sort": "alphabetical" },
-        { "type": "[static-methods]", "sort": "alphabetical" },
-        { "type": "[properties]", "sort": "alphabetical" },
-        { "type": "[conventional-private-properties]", "sort": "alphabetical" },
-        "constructor",
-        { "type": "[method]", "sort": "alphabetical" },
-        { "type": "[conventional-private-methods]", "sort": "alphabetical" }
-      ]
-    }]
+    "sort-imports": ["error", {}],
+    "sort-class-members/sort-class-members": [
+      2,
+      {
+        "accessorPairPositioning": "getThenSet",
+        "order": [
+          { "type": "[static-properties]", "sort": "alphabetical" },
+          { "type": "[static-methods]", "sort": "alphabetical" },
+          { "type": "[properties]", "sort": "alphabetical" },
+          { "type": "[conventional-private-properties]", "sort": "alphabetical" },
+          "constructor",
+          { "type": "[method]", "sort": "alphabetical" },
+          { "type": "[conventional-private-methods]", "sort": "alphabetical" }
+        ]
+      }
+    ]
   }
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,14 +1,14 @@
-import {asyncify, mapLimit} from 'async';
-import {Pod} from './pod';
-import {Route, StaticRoute} from './router';
 import * as cliProgress from 'cli-progress';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as fsPath from 'path';
 import * as os from 'os';
-import * as utils from './utils';
-import * as util from 'util';
 import * as stream from 'stream';
+import * as util from 'util';
+import * as utils from './utils';
+import {Route, StaticRoute} from './router';
+import {asyncify, mapLimit} from 'async';
+import {Pod} from './pod';
 
 interface Artifact {
   tempPath: string;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,10 +1,10 @@
+import * as yaml from 'js-yaml';
+import {Collection} from './collection';
 import {Document} from './document';
+import {Locale} from './locale';
 import {Pod} from './pod';
 import {Route} from './router';
 import {StaticFile} from './static';
-import * as yaml from 'js-yaml';
-import {Collection} from './collection';
-import {Locale} from './locale';
 import {TranslationString} from './string';
 
 export default class Cache {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,7 +1,7 @@
-import {Pod} from './pod';
 import * as fs from 'fs';
 import * as fsPath from 'path';
 import {Locale, LocaleSet} from './locale';
+import {Pod} from './pod';
 
 export class Collection {
   path: string;

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,5 +1,5 @@
-import {Pod} from '../pod';
 import * as fs from 'fs';
+import {Pod} from '../pod';
 
 interface BuildOptions {
   outputDirectory?: string;

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,8 +1,8 @@
-import {createApp} from '../server';
-import {Pod} from '../pod';
 import * as _colors from 'colors';
 import * as fs from 'fs';
+import {Pod} from '../pod';
 import Watcher from '../watcher';
+import {createApp} from '../server';
 
 interface ServeOptions {
   site: string;

--- a/src/document.ts
+++ b/src/document.ts
@@ -1,9 +1,9 @@
+import * as fsPath from 'path';
+import * as utils from './utils';
 import {Locale, LocaleSet} from './locale';
 import {Pod} from './pod';
 import {Renderer} from './renderer';
 import {Url} from './url';
-import * as fsPath from 'path';
-import * as utils from './utils';
 
 const DEFAULT_RENDERER = 'njk';
 const DEFAULT_VIEW = '/views/base.njk';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import {createCommand} from 'commander';
+import * as packageData from '../package.json';
 import {BuildCommand} from './commands/build';
 import {ServeCommand} from './commands/serve';
-import * as packageData from '../package.json';
+import {createCommand} from 'commander';
 
 export const VERSION = packageData.version;
 export const MIN_NODE_VERSION = 10;

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -1,17 +1,17 @@
-import {Builder} from './builder';
-import {Document} from './document';
-import {existsSync, readFileSync} from 'fs';
-import {Router} from './router';
-import {join} from 'path';
-import {getRenderer} from './renderer';
-import {Environment} from './environment';
-import {Collection} from './collection';
-import * as yaml from 'js-yaml';
 import * as utils from './utils';
-import {StaticFile} from './static';
-import Cache from './cache';
+import * as yaml from 'js-yaml';
 import {Locale, LocaleSet} from './locale';
-import {TranslationString, StringOptions} from './string';
+import {StringOptions, TranslationString} from './string';
+import {existsSync, readFileSync} from 'fs';
+import {Builder} from './builder';
+import Cache from './cache';
+import {Collection} from './collection';
+import {Document} from './document';
+import {Environment} from './environment';
+import {Router} from './router';
+import {StaticFile} from './static';
+import {getRenderer} from './renderer';
+import {join} from 'path';
 
 export class Pod {
   static DefaultLocale = 'en';

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,7 +1,7 @@
-import {Pod} from './pod';
-import marked from 'marked';
 import * as nunjucks from 'nunjucks';
 import * as utils from './utils';
+import {Pod} from './pod';
+import marked from 'marked';
 
 export class Renderer {
   pod: Pod;

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,10 +1,10 @@
 import * as fsPath from 'path';
+import * as utils from './utils';
 import {Document} from './document';
 import {Locale} from './locale';
 import {Pod} from './pod';
 import {StaticFile} from './static';
 import {Url} from './url';
-import * as utils from './utils';
 
 export class Router {
   pod: Pod;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
+import * as fsPath from 'path';
 import express = require('express');
 import {Pod} from './pod';
-import * as fsPath from 'path';
 import {StaticRoute} from './router';
 
 export class Server {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
-import {Pod} from './pod';
 import * as fs from 'fs';
 import * as fsPath from 'path';
 import * as yaml from 'js-yaml';
 import {Document} from './document';
+import {Pod} from './pod';
 
 export function interpolate(pod: Pod, string: string, params: any) {
   // Cache created functions to avoid memory leak.


### PR DESCRIPTION
Uses the default sorting options for `sort-imports`.

See https://eslint.org/docs/rules/sort-imports