### PR TITLE
Update file and yaml operation functions for consistency.

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -135,7 +135,7 @@ export class Builder {
   getExistingManifest(): BuildManifest | null {
     const path = this.manifestPodPath;
     if (this.pod.fileExists(path)) {
-      return JSON.parse(this.pod.readFile(this.manifestPodPath));
+      return JSON.parse(this.pod.fileRead(this.manifestPodPath));
     }
     return null;
   }

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -55,7 +55,7 @@ export class Collection {
     if (!this.exists) {
       return {};
     }
-    this._fields = this.pod.readYaml(this.collectionPath);
+    this._fields = this.pod.yamlRead(this.collectionPath);
     return this._fields;
   }
 

--- a/src/document.ts
+++ b/src/document.ts
@@ -126,7 +126,7 @@ export class Document {
     if (this.ext === '.md') {
       this.initPartsFromFrontMatter(); // Set this._fields.
     } else {
-      this._fields = this.pod.readYaml(this.path);
+      this._fields = this.pod.yamlRead(this.path);
     }
     return this._fields;
   }
@@ -135,7 +135,7 @@ export class Document {
     if (this._content !== null) {
       return this._content;
     }
-    this._content = this.pod.readFile(this.path);
+    this._content = this.pod.fileRead(this.path);
     return this._content;
   }
 
@@ -161,7 +161,7 @@ export class Document {
     if (result.frontMatter === null) {
       this._fields = {};
     } else {
-      this._fields = this.pod.readYamlString(result.frontMatter, this.path);
+      this._fields = this.pod.yamlReadString(result.frontMatter, this.path);
     }
   }
 }

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -26,7 +26,7 @@ export class Locale {
   }
 
   get translations() {
-    return this.pod.readYaml(this.podPath)['translations'];
+    return this.pod.yamlRead(this.podPath)['translations'];
   }
 
   toTranslationString(value: string | TranslationString) {

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -61,8 +61,13 @@ export class Pod {
     this.cache.docs[key] = new Document(this, path, locale);
     return this.cache.docs[key];
   }
+
   fileExists(path: string) {
     return existsSync(this.getAbsoluteFilePath(path));
+  }
+
+  fileRead(path: string) {
+    return readFileSync(this.getAbsoluteFilePath(path), 'utf8');
   }
 
   getAbsoluteFilePath(path: string) {
@@ -81,30 +86,6 @@ export class Pod {
   get locales(): Set<Locale> {
     // TODO: Replace with amagaki.yaml?locales.
     return new LocaleSet();
-  }
-
-  readFile(path: string) {
-    return readFileSync(this.getAbsoluteFilePath(path), 'utf8');
-  }
-
-  readYaml(path: string) {
-    if (this.cache.yamls[path]) {
-      return this.cache.yamls[path];
-    }
-    this.cache.yamls[path] = yaml.load(this.readFile(path), {
-      schema: this.yamlSchema,
-    });
-    return this.cache.yamls[path];
-  }
-
-  readYamlString(content: string, cacheKey: string) {
-    if (this.cache.yamlStrings[cacheKey]) {
-      return this.cache.yamlStrings[cacheKey];
-    }
-    this.cache.yamlStrings[cacheKey] = yaml.load(content, {
-      schema: this.yamlSchema,
-    });
-    return this.cache.yamlStrings[cacheKey];
   }
 
   renderer(path: string) {
@@ -130,6 +111,26 @@ export class Pod {
 
   walk(path: string) {
     return utils.walk(this.getAbsoluteFilePath(path), [], this.root);
+  }
+
+  yamlRead(path: string) {
+    if (this.cache.yamls[path]) {
+      return this.cache.yamls[path];
+    }
+    this.cache.yamls[path] = yaml.load(this.fileRead(path), {
+      schema: this.yamlSchema,
+    });
+    return this.cache.yamls[path];
+  }
+
+  yamlReadString(content: string, cacheKey: string) {
+    if (this.cache.yamlStrings[cacheKey]) {
+      return this.cache.yamlStrings[cacheKey];
+    }
+    this.cache.yamlStrings[cacheKey] = yaml.load(content, {
+      schema: this.yamlSchema,
+    });
+    return this.cache.yamlStrings[cacheKey];
   }
 
   get yamlSchema() {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -70,7 +70,7 @@ class NunjucksPodLoader extends nunjucks.Loader {
 
   getSource(name: string) {
     return {
-      src: this.pod.readFile(name),
+      src: this.pod.fileRead(name),
       path: name,
       noCache: false,
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,7 @@ export function createYamlSchema(pod: Pod) {
       // value can be: /content/partials/base.yaml?foo.bar.baz
       const parts = value.split('?');
       const podPath = parts[0];
-      const result = pod.readYaml(podPath);
+      const result = pod.yamlRead(podPath);
       if (parts.length > 1) {
         const query = parts[1].split('.');
         // TODO: Implement nested lookups.


### PR DESCRIPTION
Changes the `readFile` to `fileRead` and `readYaml` to `yamlRead` and `readYamlString` to `yamlReadString` so that it groups the operation by the 'type' of thing you are operating on. (we also have things like `fileExists`, and `yamlSchema`, etc)