### PR TITLE
Add initial plugin support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,7 @@ To unlink (the order is important):
 - When using VSCode, we recommend the following extensions (see below).
 
 ```
+amatiasq.sort-imports
 dbaeumer.vscode-eslint
 ```
 

--- a/example/amagaki.js
+++ b/example/amagaki.js
@@ -1,0 +1,5 @@
+module.exports = function (pod) {
+  pod.plugins.addNunjucksFilter('testPluginFilter', value => {
+    return `${value}--TESTING`;
+  });
+};

--- a/example/views/partials/debug.njk
+++ b/example/views/partials/debug.njk
@@ -1,4 +1,7 @@
 <div class="debug">
+    Test plugin:
+    {{"Hello World"|testPluginFilter}}
+
     Doc:
     {{doc|safe}}
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,22 @@
 import {NunjucksRenderer, Renderer} from './renderer';
+
 import {Pod} from './pod';
 
+/**
+ * The plugin manager provides a mechanism for sites to use a defined interface
+ * for extending Amagaki functionality. By adding an `amagaki.js` file to the
+ * site root, sites have access to run custom code when pods are instantiated.
+ *
+ * The primary purpose of doing so is to allow the custom code to interact with
+ * pods through the plugin manager, which provides a guaranteed way for sites to
+ * extend Amagaki functionality.
+ *
+ * While sites can reach into the pod structure and manipulate it, the
+ * preferred/stable way extend functionality is through methods of this
+ * `PluginManager` class, as we will attempt to preserve functionality offered
+ * through this interface across Amagaki versions, and provide new supported
+ * ways to interact with pods over time.
+ */
 export class PluginManager {
   pod: Pod;
   renderers: Record<string, Renderer>;
@@ -10,14 +26,34 @@ export class PluginManager {
     this.renderers = {};
   }
 
+  // TODO(jeremydw): Rename this to `addTemplateEngine`. I think we want to call
+  // "renderers" template engines as that is a more generally understood term
+  // for this in the JavaScript community.
+  /**
+   * Adds a custom renderer to the pod that can be used to render templates or
+   * dynamic data.
+   * @param extension The file extension the renderer supports, including
+   * leading dot (e.g. `.njk`).
+   * @param rendererClass A subclass of `renderer.Renderer`. The renderer must
+   * implement an async `render` method.
+   */
   addRenderer(extension: string, rendererClass: typeof Renderer) {
     this.renderers[extension] = new rendererClass(this.pod);
   }
 
+  /**
+   * Adds a filter to the inbuilt Nunjucks environment.
+   * @param name The name of the filter to register. For example, if the name is
+   * "foo", it is callable within Nunjucks as `{{"Hello World"|foo}}`.
+   * @param filterFunction The filter function.
+   */
   addNunjucksFilter(name: string, filterFunction: (...args: any[]) => any) {
     (this.renderers['.njk'] as NunjucksRenderer).env.addFilter(
       name,
       filterFunction
     );
   }
+
+  // TODO: Implement additional plugin methods like `addRouteProvider`.
+  // TODO: Implement `addYamlType`.
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,23 @@
+import {NunjucksRenderer, Renderer} from './renderer';
+import {Pod} from './pod';
+
+export class PluginManager {
+  pod: Pod;
+  renderers: Record<string, Renderer>;
+
+  constructor(pod: Pod) {
+    this.pod = pod;
+    this.renderers = {};
+  }
+
+  addRenderer(extension: string, rendererClass: typeof Renderer) {
+    this.renderers[extension] = new rendererClass(this.pod);
+  }
+
+  addNunjucksFilter(name: string, filterFunction: (...args: any[]) => any) {
+    (this.renderers['.njk'] as NunjucksRenderer).env.addFilter(
+      name,
+      filterFunction
+    );
+  }
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,5 +1,6 @@
 import * as nunjucks from 'nunjucks';
 import * as utils from './utils';
+
 import {Pod} from './pod';
 import marked from 'marked';
 
@@ -10,23 +11,10 @@ export class Renderer {
     this.pod = pod;
   }
 
-  configure() {}
-
   async render(template: string, context: any): Promise<string> {
     throw new Error();
   }
 }
-
-export function getRenderer(path: string) {
-  if (path.endsWith('.njk')) {
-    return NunjucksRenderer;
-  } else if (path.endsWith('.js')) {
-    return JavaScriptRenderer;
-  } // TODO: Raise if no renderer available.
-  return NunjucksRenderer;
-}
-
-export class JavaScriptRenderer extends Renderer {}
 
 export class NunjucksRenderer extends Renderer {
   env: nunjucks.Environment;


### PR DESCRIPTION
Fixes #2

Sites can run custom code by using an `amagaki.js` file in the pod root, which essentially acts as a hook into the site. This PR shows how to write custom repo-local plugins. Presumably external plugins could be added via `npm install` and import statements within `amagaki.js`.

Usage:
1. Add `amagaki.js` to the site root. The `pod` instance is passed into the default exported function.
2. Call one of the methods on the `pod.plugins` object.

Please review:
- The naming of things
- The concept of interacting with the pod using `pod.plugins`

PR doesn't implement:
- TypeScript for `amagaki.ts`.
- A YAML-based configuration file e.g. `amagaki.yaml`.

If this approach is successful we likely will have no need for configuring plugins with amagai.yaml, and the YAML file can solely be for core configurations (localizations, metadata, routes, environments, etc. like Grow).