### PR TITLE
Convert from `Renderer` to `TemplateEngine`.

### DIFF
--- a/example/amagaki.js
+++ b/example/amagaki.js
@@ -1,4 +1,5 @@
 const ExamplePlugin = require('./plugins/example');
+const yaml = require('js-yaml');
 
 module.exports = function (pod) {
   pod.configure({
@@ -18,4 +19,19 @@ module.exports = function (pod) {
   });
 
   pod.plugins.register(ExamplePlugin, {});
+
+  // Shortcut method for adding custom yaml types.
+  const yamlPlugin = pod.plugins.get('YamlPlugin');
+  yamlPlugin.addType(
+    new yaml.Type('!a.Bar', {
+      kind: 'scalar',
+      resolve: () => {
+        return true;
+      },
+      construct: value => {
+        return `Bar: ${value}`;
+      },
+      represent: value => value,
+    })
+  );
 };

--- a/example/amagaki.js
+++ b/example/amagaki.js
@@ -20,6 +20,11 @@ module.exports = function (pod) {
 
   pod.plugins.register(ExamplePlugin, {});
 
+  // Shortcut method for adding custom nunjucks filter and global.
+  const nunjucksPlugin = pod.plugins.get('NunjucksPlugin');
+  nunjucksPlugin.addFilter('testShortcutFilter', value => `${value}--SHORTCUT`);
+  nunjucksPlugin.addGlobal('copyrightYear', () => new Date().getFullYear());
+
   // Shortcut method for adding custom yaml types.
   const yamlPlugin = pod.plugins.get('YamlPlugin');
   yamlPlugin.addType(

--- a/example/amagaki.js
+++ b/example/amagaki.js
@@ -30,12 +30,8 @@ module.exports = function (pod) {
   yamlPlugin.addType(
     new yaml.Type('!a.Bar', {
       kind: 'scalar',
-      resolve: () => {
-        return true;
-      },
-      construct: value => {
-        return `Bar: ${value}`;
-      },
+      resolve: () => true,
+      construct: value => `Bar: ${value}`,
       represent: value => value,
     })
   );

--- a/example/content/pages/index.yaml
+++ b/example/content/pages/index.yaml
@@ -23,7 +23,7 @@ partials:
       title: Magna do magna occaecat irure.
       body: Esse in dolor anim excepteur incididunt laborum pariatur consequat. Occaecat officia elit nisi Lorem ex ex mollit aliqua ipsum fugiat quis amet sit. Mollit dolore cillum ea commodo ullamco cillum minim nisi et reprehenderit consectetur aute fugiat.
       buttons:
-      - label: Learn more
+      - label: !a.Bar Learn more
         url: https://example.com
   - asset:
       url: https://placeholder-dot-madebygoog.appspot.com/4x3.svg

--- a/example/plugins/example.js
+++ b/example/plugins/example.js
@@ -14,8 +14,8 @@ class ExamplePlugin {
     }
   }
 
-  createYamlTypesHook(customTypes) {
-    customTypes.addType(
+  createYamlTypesHook(yamlTypeManager) {
+    yamlTypeManager.addType(
       new yaml.Type('!a.Foo', {
         kind: 'scalar',
         resolve: () => {

--- a/example/plugins/example.js
+++ b/example/plugins/example.js
@@ -6,9 +6,9 @@ class ExamplePlugin {
     this.config = config;
   }
 
-  createRendererHook(renderer) {
-    if (renderer.constructor.name === 'NunjucksRenderer') {
-      renderer.env.addFilter('testPluginFilter', value => {
+  createTemplateEngineHook(templateEngine, extension) {
+    if (templateEngine.constructor.name === 'NunjucksTemplateEngine') {
+      templateEngine.env.addFilter('testPluginFilter', value => {
         return `${value}--TESTING`;
       });
     }

--- a/example/views/partials/debug.njk
+++ b/example/views/partials/debug.njk
@@ -1,7 +1,4 @@
 <div class="debug">
-    Test plugin:
-    {{"Hello World"|testPluginFilter}}
-
     Doc:
     {{doc|safe}}
 
@@ -30,4 +27,7 @@
         {% endfor %}
     </ul>
     #}
+
+    Test plugins:
+    {{"Hello World"|testPluginFilter}}, {{"Hello World"|testShortcutFilter}}, {{copyrightYear()}}
 </div>

--- a/src/document.ts
+++ b/src/document.ts
@@ -2,10 +2,8 @@ import * as fsPath from 'path';
 import * as utils from './utils';
 import {Locale, LocaleSet} from './locale';
 import {Pod} from './pod';
-import {Renderer} from './renderer';
 import {Url} from './url';
 
-const DEFAULT_RENDERER = 'njk';
 const DEFAULT_VIEW = '/views/base.njk';
 
 interface DocumentParts {
@@ -46,7 +44,6 @@ export class Document {
   path: string;
   locale: Locale;
   pod: Pod;
-  renderer: Renderer;
   readonly ext: string;
   private parts: DocumentParts;
   private _content?: string | null;
@@ -55,7 +52,6 @@ export class Document {
   constructor(pod: Pod, path: string, locale: Locale) {
     this.pod = pod;
     this.path = path;
-    this.renderer = pod.renderer(DEFAULT_RENDERER);
     this.locale = locale;
     this.ext = fsPath.extname(this.path);
     this.parts = {};
@@ -95,7 +91,8 @@ export class Document {
         static: this.pod.staticFile.bind(this.pod),
       },
     };
-    return this.renderer.render(this.view, context);
+    const templateEngine = this.pod.engines.getEngineByFilename(this.view);
+    return templateEngine.render(this.view, context);
   }
 
   /**

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -20,7 +20,12 @@ export interface PluginComponent {
    * @see {@link CustomYamlTypes} for adding custom yaml types.
    */
   createYamlTypesHook?: (yamlTypeManager: YamlTypeManager) => void;
-  [x: string]: any; // Allows for referencing arbitrary indexes.
+  /**
+   * Plugins can define any other properties and methods.
+   *
+   * Methods ending in `Hook` are reserved for future plugin hook handlers.
+   */
+  [x: string]: any;
 }
 
 export interface PluginConstructor {

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,15 +1,32 @@
+import {TemplateEngineComponent, TemplateEngineManager} from './templateEngine';
 import {CustomYamlTypes} from './utils';
+import {NunjucksPlugin} from './plugins/nunjucks';
 import {Pod} from './pod';
-import {Renderer} from './renderer';
+import {YamlPlugin} from './plugins/yaml';
+
+export const BUILT_IN_PLUGINS = [NunjucksPlugin, YamlPlugin];
 
 /**
  * Interface for defining plugins to work with amagaki.
  */
 export interface PluginComponent {
   /**
-   * Hook for manipulating the renderer after it is initially created.
+   * Hook for manipulating the template engine after it is initially created.
+   *
+   * Used for creating template filters, globals, macros, etc.
    */
-  createRendererHook?: (renderer: Renderer) => void;
+  createTemplateEngineHook?: (
+    templateEngine: TemplateEngineComponent,
+    extension: string
+  ) => void;
+  /**
+   * Hook for managing the available template engines for rendering.
+   *
+   * Used for associating new template engines with file extensions.
+   */
+  createTemplateEngineManagerHook?: (
+    templateEngineManager: TemplateEngineManager
+  ) => void;
   /**
    * Hook for defining custom yaml types for the yaml schema.
    * @see {@link CustomYamlTypes} for adding custom yaml types.

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,10 +1,6 @@
-import {TemplateEngineComponent, TemplateEngineManager} from './templateEngine';
 import {CustomYamlTypes} from './utils';
-import {NunjucksPlugin} from './plugins/nunjucks';
 import {Pod} from './pod';
-import {YamlPlugin} from './plugins/yaml';
-
-export const BUILT_IN_PLUGINS = [NunjucksPlugin, YamlPlugin];
+import {TemplateEngineComponent} from './templateEngine';
 
 /**
  * Interface for defining plugins to work with amagaki.

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -20,14 +20,6 @@ export interface PluginComponent {
     extension: string
   ) => void;
   /**
-   * Hook for managing the available template engines for rendering.
-   *
-   * Used for associating new template engines with file extensions.
-   */
-  createTemplateEngineManagerHook?: (
-    templateEngineManager: TemplateEngineManager
-  ) => void;
-  /**
    * Hook for defining custom yaml types for the yaml schema.
    * @see {@link CustomYamlTypes} for adding custom yaml types.
    */

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,6 +1,6 @@
-import {CustomYamlTypes} from './utils';
 import {Pod} from './pod';
 import {TemplateEngineComponent} from './templateEngine';
+import {YamlTypeManager} from './plugins/yaml';
 
 /**
  * Interface for defining plugins to work with amagaki.
@@ -19,7 +19,7 @@ export interface PluginComponent {
    * Hook for defining custom yaml types for the yaml schema.
    * @see {@link CustomYamlTypes} for adding custom yaml types.
    */
-  createYamlTypesHook?: (customTypes: CustomYamlTypes) => void;
+  createYamlTypesHook?: (yamlTypeManager: YamlTypeManager) => void;
   [x: string]: any; // Allows for referencing arbitrary indexes.
 }
 

--- a/src/plugins/yaml.ts
+++ b/src/plugins/yaml.ts
@@ -1,5 +1,4 @@
 import * as yaml from 'js-yaml';
-import {CustomYamlTypes} from '../utils';
 import {PluginComponent} from '../plugins';
 import {Pod} from '../pod';
 
@@ -22,8 +21,8 @@ export class YamlPlugin implements PluginComponent {
     this.shortcutTypes.push(type);
   }
 
-  createYamlTypesHook(customTypes: CustomYamlTypes) {
-    customTypes.addType(
+  createYamlTypesHook(yamlTypeManager: YamlTypeManager) {
+    yamlTypeManager.addType(
       new yaml.Type('!a.Doc', {
         kind: 'scalar',
         resolve: data => {
@@ -39,7 +38,7 @@ export class YamlPlugin implements PluginComponent {
       })
     );
 
-    customTypes.addType(
+    yamlTypeManager.addType(
       new yaml.Type('!a.Static', {
         kind: 'scalar',
         resolve: data => {
@@ -55,7 +54,7 @@ export class YamlPlugin implements PluginComponent {
       })
     );
 
-    customTypes.addType(
+    yamlTypeManager.addType(
       new yaml.Type('!a.String', {
         kind: 'mapping',
         resolve: data => {
@@ -73,7 +72,7 @@ export class YamlPlugin implements PluginComponent {
       })
     );
 
-    customTypes.addType(
+    yamlTypeManager.addType(
       new yaml.Type('!a.Yaml', {
         kind: 'scalar',
         resolve: data => {
@@ -102,7 +101,22 @@ export class YamlPlugin implements PluginComponent {
     );
 
     for (const shortcutType of this.shortcutTypes) {
-      customTypes.addType(shortcutType);
+      yamlTypeManager.addType(shortcutType);
     }
+  }
+}
+
+/**
+ * Custom yaml type manager for adding custom yaml types.
+ */
+export class YamlTypeManager {
+  types: Array<yaml.Type>;
+
+  constructor() {
+    this.types = [];
+  }
+
+  addType(yamlType: yaml.Type) {
+    this.types.push(yamlType);
   }
 }

--- a/src/plugins/yaml.ts
+++ b/src/plugins/yaml.ts
@@ -1,0 +1,97 @@
+import * as yaml from 'js-yaml';
+import {CustomYamlTypes} from '../utils';
+import {PluginComponent} from '../plugins';
+import {Pod} from '../pod';
+
+/**
+ * Plugin providing built-in custom yaml types.
+ */
+export class YamlPlugin implements PluginComponent {
+  config: Record<string, any>;
+  pod: Pod;
+
+  constructor(pod: Pod, config: Record<string, any>) {
+    this.pod = pod;
+    this.config = config;
+  }
+
+  createYamlTypesHook(customTypes: CustomYamlTypes) {
+    customTypes.addType(
+      new yaml.Type('!a.Doc', {
+        kind: 'scalar',
+        resolve: data => {
+          // TODO: Validate this is in the content folder.
+          return data !== null && data.startsWith('/');
+        },
+        construct: podPath => {
+          return this.pod.doc(podPath);
+        },
+        represent: doc => {
+          return doc;
+        },
+      })
+    );
+
+    customTypes.addType(
+      new yaml.Type('!a.Static', {
+        kind: 'scalar',
+        resolve: data => {
+          // TODO: Add more validation?
+          return data !== null && data.startsWith('/');
+        },
+        construct: podPath => {
+          return this.pod.staticFile(podPath);
+        },
+        represent: staticFile => {
+          return staticFile;
+        },
+      })
+    );
+
+    customTypes.addType(
+      new yaml.Type('!a.String', {
+        kind: 'mapping',
+        resolve: data => {
+          return (
+            typeof data === 'string' ||
+            (typeof data === 'object' && 'value' in data)
+          );
+        },
+        construct: value => {
+          return this.pod.string(value);
+        },
+        represent: string => {
+          return string;
+        },
+      })
+    );
+
+    customTypes.addType(
+      new yaml.Type('!a.Yaml', {
+        kind: 'scalar',
+        resolve: data => {
+          // TODO: Add more validation?
+          return data !== null && data.startsWith('/');
+        },
+        construct: value => {
+          // value can be: /content/partials/base.yaml
+          // value can be: /content/partials/base.yaml?foo
+          // value can be: /content/partials/base.yaml?foo.bar.baz
+          const parts = value.split('?');
+          const podPath = parts[0];
+          const result = this.pod.readYaml(podPath);
+          if (parts.length > 1) {
+            const query = parts[1].split('.');
+            // TODO: Implement nested lookups.
+            return result[query[0]];
+          } else {
+            return result;
+          }
+        },
+        represent: string => {
+          return string;
+        },
+      })
+    );
+  }
+}

--- a/src/plugins/yaml.ts
+++ b/src/plugins/yaml.ts
@@ -9,10 +9,17 @@ import {Pod} from '../pod';
 export class YamlPlugin implements PluginComponent {
   config: Record<string, any>;
   pod: Pod;
+  private shortcutTypes: Array<yaml.Type>;
 
   constructor(pod: Pod, config: Record<string, any>) {
     this.pod = pod;
     this.config = config;
+    this.shortcutTypes = [];
+  }
+
+  // Shortcut for adding custom yaml types without creating a full plugin.
+  addType(type: yaml.Type) {
+    this.shortcutTypes.push(type);
   }
 
   createYamlTypesHook(customTypes: CustomYamlTypes) {
@@ -93,5 +100,9 @@ export class YamlPlugin implements PluginComponent {
         },
       })
     );
+
+    for (const shortcutType of this.shortcutTypes) {
+      customTypes.addType(shortcutType);
+    }
   }
 }

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -75,7 +75,7 @@ export class Pod {
     };
     this.cache = new Cache(this);
 
-    // Register built-in plugins before the amagaki.js config to be consistent
+    // Register built-in plugins before the amagaki.js config to be consistent with
     // external plugin hooks and allow external plugins to work with the built-in
     // plugins.
     for (const BuiltInPlugin of BUILT_IN_PLUGINS) {

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -1,7 +1,7 @@
 import * as utils from './utils';
 import * as yaml from 'js-yaml';
-import {BUILT_IN_PLUGINS, Plugins} from './plugins';
 import {Locale, LocaleSet} from './locale';
+import {PluginConstructor, Plugins} from './plugins';
 import {Router, StaticDirConfig} from './router';
 import {StringOptions, TranslationString} from './string';
 import {existsSync, readFileSync} from 'fs';
@@ -11,9 +11,11 @@ import {Cache} from './cache';
 import {Collection} from './collection';
 import {Document} from './document';
 import {Environment} from './environment';
+import {NunjucksPlugin} from './plugins/nunjucks';
 import {Profiler} from './profile';
 import {StaticFile} from './static';
 import {TemplateEngineManager} from './templateEngine';
+import {YamlPlugin} from './plugins/yaml';
 
 export interface LocalizationConfig {
   defaultLocale?: string;
@@ -38,6 +40,10 @@ export interface PodConfig {
  * the different elements of a site and operating on them.
  */
 export class Pod {
+  static BuiltInPlugins: Array<PluginConstructor> = [
+    NunjucksPlugin,
+    YamlPlugin,
+  ];
   static DefaultLocalization: LocalizationConfig = {
     defaultLocale: 'en',
     locales: ['en'],
@@ -78,7 +84,7 @@ export class Pod {
     // Register built-in plugins before the amagaki.js config to be consistent with
     // external plugin hooks and allow external plugins to work with the built-in
     // plugins.
-    for (const BuiltInPlugin of BUILT_IN_PLUGINS) {
+    for (const BuiltInPlugin of Pod.BuiltInPlugins) {
       this.plugins.register(BuiltInPlugin, {});
     }
 

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -4,6 +4,7 @@ import {Locale, LocaleSet} from './locale';
 import {PluginConstructor, Plugins} from './plugins';
 import {Router, StaticDirConfig} from './router';
 import {StringOptions, TranslationString} from './string';
+import {YamlPlugin, YamlTypeManager} from './plugins/yaml';
 import {existsSync, readFileSync} from 'fs';
 import {join, resolve} from 'path';
 import {Builder} from './builder';
@@ -15,7 +16,6 @@ import {NunjucksPlugin} from './plugins/nunjucks';
 import {Profiler} from './profile';
 import {StaticFile} from './static';
 import {TemplateEngineManager} from './templateEngine';
-import {YamlPlugin} from './plugins/yaml';
 
 export interface LocalizationConfig {
   defaultLocale?: string;
@@ -305,7 +305,9 @@ export class Pod {
 
     const timer = this.profiler.timer('yaml.schema', 'Yaml schema');
     try {
-      this.cache.yamlSchema = utils.createYamlSchema(this);
+      const yamlTypeManager = new YamlTypeManager();
+      this.plugins.trigger('createYamlTypes', yamlTypeManager);
+      this.cache.yamlSchema = yaml.Schema.create(yamlTypeManager.types);
     } finally {
       timer.stop();
     }

--- a/src/templateEngine.ts
+++ b/src/templateEngine.ts
@@ -15,7 +15,7 @@ export interface TemplateEngineConstructor {
 export class TemplateEngineManager {
   pod: Pod;
   private engines: Record<string, TemplateEngineComponent>;
-  extToClass: Record<string, TemplateEngineConstructor>;
+  private extToClass: Record<string, TemplateEngineConstructor>;
 
   constructor(pod: Pod) {
     this.pod = pod;

--- a/src/templateEngine.ts
+++ b/src/templateEngine.ts
@@ -1,0 +1,87 @@
+import {Pod} from './pod';
+
+export interface TemplateEngineComponent {
+  pod: Pod;
+  /**
+   * Renders the template string using the template engine and the given context.
+   */
+  render: (template: string, context: any) => Promise<string>;
+}
+
+export interface TemplateEngineConstructor {
+  new (pod: Pod): TemplateEngineComponent;
+}
+
+export class TemplateEngineManager {
+  pod: Pod;
+  private engines: Record<string, TemplateEngineComponent>;
+  extToClass: Record<string, TemplateEngineConstructor>;
+
+  constructor(pod: Pod) {
+    this.pod = pod;
+    this.engines = {};
+    this.extToClass = {};
+  }
+
+  associate(extension: string, TemplateEngineClass: TemplateEngineConstructor) {
+    if (!extension || !extension.startsWith('.')) {
+      throw new InvalidExtensionError(
+        'Template engine extensions needs to start with a period (.).'
+      );
+    }
+
+    this.extToClass[extension] = TemplateEngineClass;
+  }
+
+  getEngineByExtension(extension: string): TemplateEngineComponent {
+    if (!(extension in this.extToClass)) {
+      throw new MissingTemplateEngineError(
+        `Unable to find template engine for the ${extension} extension.`
+      );
+    }
+
+    // Only need to create one template engine instance per extension.
+    // Allows each extension's template engine to be configured separately
+    // by using the plugin hook.
+    if (!this.engines[extension]) {
+      this.engines[extension] = new this.extToClass[extension](this.pod);
+
+      // Trigger the plugin hook for new template engines.
+      this.pod.plugins.trigger(
+        'createTemplateEngine',
+        this.engines[extension],
+        extension
+      );
+    }
+
+    return this.engines[extension];
+  }
+
+  getEngineByFilename(fileName: string): TemplateEngineComponent {
+    // Go through the extensions starting with the longest extension.
+    // This allows for sub extensions to take priority. (Ex: .foo.bar > .bar).
+    const knownExtensions = Object.keys(this.extToClass).sort(
+      (a, b) => b.length - a.length
+    );
+
+    fileName = fileName.trim();
+
+    let knownExtension: string | undefined = undefined;
+    for (const ext of knownExtensions) {
+      if (fileName.endsWith(ext)) {
+        knownExtension = ext;
+      }
+    }
+
+    if (!knownExtension) {
+      throw new MissingTemplateEngineError(
+        `Unable to find template engine for the ${fileName} file name.`
+      );
+    }
+
+    return this.getEngineByExtension(knownExtension);
+  }
+}
+
+export class InvalidExtensionError extends Error {}
+export class MissingTemplateEngineError extends Error {}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as fsPath from 'path';
-import * as yaml from 'js-yaml';
 import {Document} from './document';
 import {Locale} from './locale';
 import {Pod} from './pod';
@@ -71,12 +70,6 @@ export class DataType {
 
 export function basename(path: string) {
   return path.split('/').reverse()[0];
-}
-
-export function createYamlSchema(pod: Pod) {
-  const customTypes = new CustomYamlTypes();
-  pod.plugins.trigger('createYamlTypes', customTypes);
-  return yaml.Schema.create(customTypes.types);
 }
 
 export function formatBytes(bytes: number) {
@@ -176,16 +169,4 @@ export function walk(path: string, newFiles?: string[], removePrefix?: string) {
     }
   });
   return files;
-}
-
-export class CustomYamlTypes {
-  types: Array<yaml.Type>;
-
-  constructor() {
-    this.types = [];
-  }
-
-  addType(yamlType: yaml.Type) {
-    this.types.push(yamlType);
-  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,79 +74,9 @@ export function basename(path: string) {
 }
 
 export function createYamlSchema(pod: Pod) {
-  // TODO: Expose YAML schemas for sites to register additional types.
-  const docType = new yaml.Type('!a.Doc', {
-    kind: 'scalar',
-    resolve: data => {
-      // TODO: Validate this is in the content folder.
-      return data !== null && data.startsWith('/');
-    },
-    construct: podPath => {
-      return pod.doc(podPath);
-    },
-    represent: doc => {
-      return doc;
-    },
-  });
-  const staticType = new yaml.Type('!a.Static', {
-    kind: 'scalar',
-    resolve: data => {
-      // TODO: Add more validation?
-      return data !== null && data.startsWith('/');
-    },
-    construct: podPath => {
-      return pod.staticFile(podPath);
-    },
-    represent: staticFile => {
-      return staticFile;
-    },
-  });
-  const stringType = new yaml.Type('!a.String', {
-    kind: 'mapping',
-    resolve: data => {
-      return (
-        typeof data === 'string' ||
-        (typeof data === 'object' && 'value' in data)
-      );
-    },
-    construct: value => {
-      return pod.string(value);
-    },
-    represent: string => {
-      return string;
-    },
-  });
-  const yamlType = new yaml.Type('!a.Yaml', {
-    kind: 'scalar',
-    resolve: data => {
-      // TODO: Add more validation?
-      return data !== null && data.startsWith('/');
-    },
-    construct: value => {
-      // value can be: /content/partials/base.yaml
-      // value can be: /content/partials/base.yaml?foo
-      // value can be: /content/partials/base.yaml?foo.bar.baz
-      const parts = value.split('?');
-      const podPath = parts[0];
-      const result = pod.readYaml(podPath);
-      if (parts.length > 1) {
-        const query = parts[1].split('.');
-        // TODO: Implement nested lookups.
-        return result[query[0]];
-      } else {
-        return result;
-      }
-    },
-    represent: string => {
-      return string;
-    },
-  });
-
-  const builtInTypes = [docType, staticType, stringType, yamlType];
   const customTypes = new CustomYamlTypes();
   pod.plugins.trigger('createYamlTypes', customTypes);
-
-  return yaml.Schema.create(builtInTypes.concat(customTypes.types));
+  return yaml.Schema.create(customTypes.types);
 }
 
 export function formatBytes(bytes: number) {


### PR DESCRIPTION
Add a template engine manager and move the built-in template engines into build-in plugins.

Moved the yaml custom types into a built-in yaml plugin.