### PR TITLE
Improve profiling console output.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -175,6 +175,11 @@
         "@types/node": "*"
       }
     },
+    "@types/cli-table": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.0.tgz",
+      "integrity": "sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ=="
+    },
     "@types/connect": {
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
@@ -1014,6 +1019,61 @@
       "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
       "dev": true
     },
+    "cli-table": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.4.tgz",
+      "integrity": "sha512-1vinpnX/ZERcmE443i3SZTmU5DF0rPO9DrL4I2iVAllhxzCM9SzPlHnz19fsZB78htkKZvYBvj6SZ6vXnaxmTA==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "cli-truncate": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -1466,8 +1526,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
       "version": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/async": "^3.2.5",
     "@types/cli-progress": "^3.8.0",
+    "@types/cli-table": "^0.3.0",
     "@types/express": "^4.17.9",
     "@types/js-yaml": "^3.12.5",
     "@types/marked": "^1.2.1",
@@ -56,7 +57,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@types/cli-table": "^0.3.0",
     "async": "^3.2.0",
     "cli-progress": "^3.8.2",
     "cli-table": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -56,8 +56,10 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@types/cli-table": "^0.3.0",
     "async": "^3.2.0",
     "cli-progress": "^3.8.2",
+    "cli-table": "^0.3.4",
     "commander": "^5.1.0",
     "express": "^4.17.1",
     "js-yaml": "^3.14.1",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -286,7 +286,23 @@ export class Builder {
               (createdPath.route as StaticRoute).staticFile.podPath
             );
           } else {
-            const content = await createdPath.route.build();
+            // Use the url path as a unique timer key.
+            const urlPathStub = createdPath.route.urlPath.replace(/\//g, '.');
+            const timer = this.pod.profiler.timer(
+              `builder.build${urlPathStub}`,
+              `Build: ${createdPath.route.urlPath}`,
+              {
+                path: createdPath.route.path,
+                type: createdPath.route.provider.type,
+                urlPath: createdPath.route.urlPath,
+              }
+            );
+            let content = '';
+            try {
+              content = await createdPath.route.build();
+            } finally {
+              timer.stop();
+            }
             return this.writeFileAsync(createdPath.tempPath, content);
           }
         } finally {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import {GlobalOptions} from './global';
 import {Pod} from '../pod';
+import {ProfileReport} from '../profile';
 
 interface BuildOptions {
   outputDirectory?: string;
@@ -24,7 +25,9 @@ export class BuildCommand {
       timer.stop();
     }
 
-    pod.profiler.report([], this.globalOptions.profile);
+    const report = new ProfileReport(pod.profiler);
+    report.output(this.globalOptions.profile);
+
     await pod.builder.exportBenchmark();
   }
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -81,7 +81,7 @@ export class Plugins {
   trigger(hookName: string, ...args: any[]) {
     const triggerTimer = this.pod.profiler.timer(
       `plugins.trigger.${hookName}`,
-      `Hook: ${hookName}`,
+      hookName,
       {
         trigger: hookName,
       }
@@ -94,7 +94,7 @@ export class Plugins {
         if (plugin[eventMethodName]) {
           const pluginTimer = this.pod.profiler.timer(
             `plugins.trigger.${hookName}.${plugin.constructor.name}`,
-            `${plugin.constructor.name}`,
+            plugin.constructor.name,
             {
               trigger: hookName,
               plugin: plugin.constructor.name,

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -80,10 +80,10 @@ export class Plugins {
    */
   trigger(hookName: string, ...args: any[]) {
     const triggerTimer = this.pod.profiler.timer(
-      `plugins.trigger.${hookName}`,
-      hookName,
+      `plugins.hook.${hookName}`,
+      `Hook: ${hookName}`,
       {
-        trigger: hookName,
+        hook: hookName,
       }
     );
 
@@ -93,10 +93,10 @@ export class Plugins {
       for (const plugin of this.plugins) {
         if (plugin[eventMethodName]) {
           const pluginTimer = this.pod.profiler.timer(
-            `plugins.trigger.${hookName}.${plugin.constructor.name}`,
-            plugin.constructor.name,
+            `plugins.hook.${hookName}.${plugin.constructor.name}`,
+            `${plugin.constructor.name} hook: ${hookName}`,
             {
-              trigger: hookName,
+              hook: hookName,
               plugin: plugin.constructor.name,
             }
           );

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -94,7 +94,7 @@ export class Plugins {
         if (plugin[eventMethodName]) {
           const pluginTimer = this.pod.profiler.timer(
             `plugins.trigger.${hookName}.${plugin.constructor.name}`,
-            `${plugin.constructor.name} hook: ${hookName}`,
+            `${plugin.constructor.name}`,
             {
               trigger: hookName,
               plugin: plugin.constructor.name,

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -343,7 +343,7 @@ export class ProfileReport {
       shownTimerKeys.add(timerKey);
     }
     reportOutput += this.sectionToString(
-      'Hook timers',
+      'Hooks',
       filteredTimerTypes,
       (timerKey: string, timerType: TimerType, label: string) => {
         // Indent the plugin hook information.

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -364,9 +364,12 @@ export class ProfileReport {
 
   reportTimers(shownTimerKeys: Set<string>) {
     const duration = this.profiler.duration;
-    const filteredTimerTypes = this.filter(
-      (timerType: TimerType) => !shownTimerKeys.has(timerType.key)
-    );
+    const filteredTimerTypes = this.filter((timerType: TimerType) => {
+      return (
+        !ProfileReport.BUILD_REPORT_REGEX.test(timerType.key) &&
+        !shownTimerKeys.has(timerType.key)
+      );
+    });
 
     // Mark timerType keys as being shown.
     filteredTimerTypes.forEach((timerType: TimerType) =>

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -257,9 +257,12 @@ export class ProfileReport {
     const filteredTimerTypes = this.filter((timerType: TimerType) => {
       return ProfileReport.HOOK_REPORT_REGEX.test(timerType.key);
     });
-    for (const timerType of filteredTimerTypes) {
-      shownTimerKeys.add(timerType.key);
-    }
+
+    // Mark timerType keys as being shown.
+    filteredTimerTypes.forEach((timerType: TimerType) =>
+      shownTimerKeys.add(timerType.key)
+    );
+
     const reportSection = new ProfileReportSection(
       'Hooks',
       filteredTimerTypes,
@@ -341,9 +344,12 @@ export class ProfileReport {
       }
       return timerType.isOverThreshold(duration) && timerType.sum !== duration;
     });
-    for (const timerType of filteredTimerTypes) {
-      shownTimerKeys.add(timerType.key);
-    }
+
+    // Mark timerType keys as being shown.
+    filteredTimerTypes.forEach((timerType: TimerType) =>
+      shownTimerKeys.add(timerType.key)
+    );
+
     const reportSection = new ProfileReportSection(
       'Over threshold',
       filteredTimerTypes,
@@ -361,9 +367,12 @@ export class ProfileReport {
     const filteredTimerTypes = this.filter(
       (timerType: TimerType) => !shownTimerKeys.has(timerType.key)
     );
-    for (const timerType of filteredTimerTypes) {
-      shownTimerKeys.add(timerType.key);
-    }
+
+    // Mark timerType keys as being shown.
+    filteredTimerTypes.forEach((timerType: TimerType) =>
+      shownTimerKeys.add(timerType.key)
+    );
+
     const reportSection = new ProfileReportSection(
       'Timers',
       filteredTimerTypes,

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -334,9 +334,6 @@ export class ProfileReport {
 
     // Show hook timers.
     filteredTimerTypes = this.filter((timerKey: string) => {
-      if (shownTimerKeys.has(timerKey)) {
-        return false;
-      }
       return ProfileReport.HOOK_REPORT_REGEX.test(timerKey);
     });
     for (const timerKey of Object.keys(filteredTimerTypes)) {

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -248,8 +248,8 @@ export class ProfileReport {
     }
 
     this.reportHooks(shownTimerKeys);
-    this.reportSlowBuilds(shownTimerKeys);
     this.reportTimers(shownTimerKeys);
+    this.reportSlowBuilds(shownTimerKeys);
   }
 
   reportHooks(shownTimerKeys: Set<string>) {

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -416,13 +416,14 @@ export class ProfileReportSection {
     // Default row display.
     this.rowFunc = (timerType: TimerType) => {
       const labelValue = timerType.label || timerType.key;
+      const statsValue = `${timerType.length} calls, ${timeFormat(
+        timerType.maximum
+      )} max, ${timeFormat(timerType.average)} avg`;
       return [
         this.labelFunc ? this.labelFunc(timerType, labelValue) : labelValue,
         `${((timerType.sum / this.totalDuration) * 100).toFixed(2)}%`,
         timeFormat(timerType.sum),
-        timerType.length > 1
-          ? `${timerType.length} calls, ${timeFormat(timerType.average)} avg`
-          : '1 call',
+        timerType.length > 1 ? statsValue : '1 call',
       ];
     };
   }

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -8,16 +8,6 @@ interface TimeParts {
   seconds: number;
 }
 
-interface ProfileReportItem {
-  average: number;
-  sum: number;
-  key: string;
-  label: string;
-  count: number;
-  maximum: number;
-  minimum: number;
-}
-
 export class Profiler {
   timerTypes: Record<string, TimerType>;
 
@@ -222,31 +212,16 @@ export class Timer {
 }
 
 export class ProfileReport {
-  static HOOK_REPORT_REGEX = /^plugins\.trigger\..*/;
-  static HOOK_REPORT_SUB_REGEX = /^plugins\.trigger\.[^\.]*\./;
+  static HOOK_REPORT_REGEX = /^plugins\.hook\..*/;
+  static HOOK_REPORT_SUB_REGEX = /^plugins\.hook\.[^\.]*\./;
   static THRESHOLD = 0.2;
   static MAX_WIDTH = 80;
   logMethod: Function;
   profiler: Profiler;
-  reportItems: Record<string, ProfileReportItem>;
 
   constructor(profiler: Profiler, logMethod = console.log) {
     this.logMethod = logMethod;
     this.profiler = profiler;
-    this.reportItems = {};
-
-    for (const timerKey of Object.keys(this.profiler.timerTypes).sort()) {
-      const timerType = this.profiler.timerTypes[timerKey];
-      this.reportItems[timerKey] = {
-        average: timerType.average,
-        sum: timerType.sum,
-        key: timerKey,
-        label: timerType.label || timerType.key,
-        count: timerType.length,
-        maximum: timerType.maximum,
-        minimum: timerType.minimum,
-      };
-    }
   }
 
   filter(filterFunc: Function): Record<string, TimerType> {
@@ -345,9 +320,9 @@ export class ProfileReport {
       (timerKey: string, timerType: TimerType, label: string) => {
         // Indent the plugin hook information.
         if (ProfileReport.HOOK_REPORT_SUB_REGEX.test(timerKey)) {
-          return `  ${label}`;
+          return `  ${timerType.meta.plugin}`;
         }
-        return label;
+        return timerType.meta.hook;
       }
     );
 

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -317,7 +317,7 @@ export class ProfileReport {
     reportOutput += this.sectionToString(
       'Hooks',
       filteredTimerTypes,
-      (timerKey: string, timerType: TimerType, label: string) => {
+      (timerKey: string, timerType: TimerType) => {
         // Indent the plugin hook information.
         if (ProfileReport.HOOK_REPORT_SUB_REGEX.test(timerKey)) {
           return `  ${timerType.meta.plugin}`;

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -162,8 +162,8 @@ export class TimerType {
     return sum;
   }
 
-  isOverThreshold(totalDuration: number, threshold: number): boolean {
-    return this.sum / totalDuration >= threshold;
+  isOverThreshold(totalDuration: number): boolean {
+    return this.sum / totalDuration >= this.threshold;
   }
 
   timer(): Timer {
@@ -329,7 +329,6 @@ export class ProfileReport {
   reportThreshold(shownTimerKeys: Set<string>) {
     const duration = this.profiler.duration;
     const filteredTimerTypes = this.filter((timerType: TimerType) => {
-      const threshold = duration * timerType.threshold;
       if (shownTimerKeys.has(timerType.key)) {
         return false;
       }
@@ -340,7 +339,7 @@ export class ProfileReport {
           return false;
         }
       }
-      return timerType.sum >= threshold && timerType.sum !== duration;
+      return timerType.isOverThreshold(duration) && timerType.sum !== duration;
     });
     for (const timerType of filteredTimerTypes) {
       shownTimerKeys.add(timerType.key);


### PR DESCRIPTION
Updating the console output when running profiling to make it look nicer and easier to read.

Current output example:

```
Build command took 88.3ms (1.00% called 1x, 88.3ms each)
Document fields localization took 5.0ms (0.06% called 35x, 0.1ms each)
File exists took 2.1ms (0.02% called 133x, 15.84µs each)
File read took 1.3ms (0.02% called 20x, 66.96µs each)
Hook: createTemplateEngine took 0.1ms (0.00% called 1x, 0.1ms each)
ExamplePlugin hook: createTemplateEngine took 20.73µs (0.00% called 1x, 20.73µs each)
NunjucksPlugin hook: createTemplateEngine took 54.87µs (0.00% called 1x, 54.87µs each)
Hook: createYamlTypes took 0.2ms (0.00% called 1x, 0.2ms each)
ExamplePlugin hook: createYamlTypes took 28.44µs (0.00% called 1x, 28.44µs each)
YamlPlugin hook: createYamlTypes took 0.1ms (0.00% called 1x, 0.1ms each)
Yaml load took 4.7ms (0.05% called 9x, 0.5ms each)
Yaml schema took 0.4ms (0.00% called 1x, 0.4ms each)
```

New output example:
```
┌──────────────────────┬───────┬─────────┬────────┐
│ Hooks                │     % │    Time │ Stats  │
│ createTemplateEngine │ 0.12% │ 99.50µs │ 1 call │
│   ExamplePlugin      │ 0.02% │ 20.54µs │ 1 call │
│   NunjucksPlugin     │ 0.06% │ 54.23µs │ 1 call │
│ createYamlTypes      │ 0.19% │   0.2ms │ 1 call │
│   ExamplePlugin      │ 0.03% │ 28.38µs │ 1 call │
│   YamlPlugin         │ 0.12% │ 99.60µs │ 1 call │
└──────────────────────┴───────┴─────────┴────────┘
┌──────────────────────────────┬─────────┬────────┬───────────────────────────────────┐
│ Timers                       │       % │   Time │ Stats                             │
│ Build command                │ 100.00% │ 85.9ms │ 1 call                            │
│ Document fields localization │   5.91% │  5.1ms │ 35 calls, 2.6ms max, 0.1ms avg    │
│ File exists                  │   2.43% │  2.1ms │ 133 calls, 0.1ms max, 15.73µs avg │
│ File read                    │   1.55% │  1.3ms │ 20 calls, 0.1ms max, 66.74µs avg  │
│ Yaml load                    │   5.54% │  4.8ms │ 9 calls, 2.5ms max, 0.5ms avg     │
│ Yaml schema                  │   0.42% │  0.4ms │ 1 call                            │
└──────────────────────────────┴─────────┴────────┴───────────────────────────────────┘
┌─────────────────┬────────┐
│ Slowest builds  │   Time │
│ /about/         │ 40.8ms │
│ /intl/de/about/ │ 23.3ms │
│ /intl/fi/about/ │ 22.9ms │
│ /intl/fr/about/ │ 22.7ms │
│ /intl/it/about/ │ 22.5ms │
│ /intl/ja/about/ │ 22.3ms │
│ /intl/ko/about/ │ 22.1ms │
│ /intl/nl/about/ │ 22.0ms │
│ /bio/           │ 21.8ms │
│ /intl/de/bio/   │ 21.6ms │
│ /intl/fi/bio/   │ 21.5ms │
│ /intl/fr/bio/   │ 21.3ms │
│ /intl/it/bio/   │ 21.2ms │
└─────────────────┴────────┘
```