### PR TITLE
Collection path for documents to reference relative collection path.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@amagaki/amagaki",
-  "version": "0.1.7",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/document.ts
+++ b/src/document.ts
@@ -142,7 +142,6 @@ export class Document {
   get pathFormat() {
     // TODO: See if this is what we want to do, or if we want path formats to be
     // exclusively defined by the router.
-    // return '/pages/${doc.basename}/';
     if (this.locale.id === this.pod.defaultLocale.id) {
       return (
         (this.fields && this.fields['$path']) ||

--- a/src/document.ts
+++ b/src/document.ts
@@ -110,12 +110,25 @@ export class Document {
   }
 
   /**
-   * Returns the document's basename. A document's basename is its full filename
-   * (including extension), for example, the basename for
-   * `/content/pages/index.yaml` is `index.yaml`.
+   * Returns the document's basename.
+   *
+   * A document's basename is its filename without the extension.
+   *
+   * The `basename` for `/content/pages/index.yaml` is `index`.
    */
   get basename() {
     return fsPath.basename(this.path).split('.')[0];
+  }
+
+  /**
+   * Returns the document's relative path within the collection.
+   *
+   * The `collectionPath` for `/content/pages/sub/path/index.yaml` is `/sub/path`.
+   */
+  get collectionPath() {
+    const documentDirectory = fsPath.dirname(this.path);
+    const collectionDirectory = this.collection?.path || '';
+    return documentDirectory.slice(collectionDirectory.length);
   }
 
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -298,6 +298,11 @@ export class DocumentRoute extends Route {
     urlPath = utils.interpolate(this.pod, this.doc.pathFormat, {
       doc: this.doc,
     }) as string;
+
+    // Clean up multiple slashes in url paths.
+    // Path format params can be blank or return with starting or ending slashes.
+    urlPath = urlPath.replace(/\/{2,}/g, '/');
+
     this.pod.cache.urlPaths.set(this.doc, urlPath);
     return urlPath;
   }


### PR DESCRIPTION
Allows for using `${doc.collectionPath}` in url formatting.

For example:

Given a collection (`/content/pages/_collection.yaml`) with a page in a
sub directory (`/content/pages/sub/other/page.yaml`) then `doc.collectionPath`
would be `/sub/other`.

When used in a `$path: /${doc.collectionPath}/${doc.basename}/` for the collection `$path`.
the `/content/pages/sub/other/page.yaml` url path would become `/sub/other/page/`.