### PR TITLE
Pod level locales need to be `Locale` objects not `string`s.

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -192,7 +192,7 @@ export class Document {
         })
       );
     }
-    if (this.collection) {
+    if (this.collection?.locales) {
       return this.collection.locales;
     }
     return this.pod.locales;

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -204,7 +204,11 @@ export class Pod {
    * `amagaki.js`.
    */
   get locales(): Set<Locale> {
-    return new LocaleSet(this.localization.locales);
+    return new LocaleSet(
+      (this.localization.locales || []).map((locale: string) => {
+        return this.locale(locale);
+      })
+    );
   }
 
   /**


### PR DESCRIPTION
The fallback to use pod level locales when a document and collection do not define `locales` of their own was running into issues where the `Locale` set included `string` locale ids instead of `Locale` objects.