### PR TITLE
Add fingerprint and exists method to StaticFile. Fixes #52

### DIFF
--- a/fixtures/static/src/static/file.txt
+++ b/fixtures/static/src/static/file.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/src/static.test.ts
+++ b/src/static.test.ts
@@ -11,8 +11,5 @@ test('Exists', (t: ExecutionContext) => {
 test('Fingerprint', (t: ExecutionContext) => {
   const pod = new Pod('./fixtures/static/');
   const staticFile = pod.staticFile('/src/static/file.txt');
-  t.is(
-    staticFile.fingerprint(),
-    '7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069'
-  );
+  t.is(staticFile.fingerprint, 'ed076287532e86365e841e92bfc50d8c');
 });

--- a/src/static.test.ts
+++ b/src/static.test.ts
@@ -1,0 +1,18 @@
+import {ExecutionContext} from 'ava';
+import {Pod} from './pod';
+import test from 'ava';
+
+test('Exists', (t: ExecutionContext) => {
+  const pod = new Pod('./fixtures/static/');
+  t.true(pod.staticFile('/src/static/file.txt').exists);
+  t.false(pod.staticFile('/src/static/bad.txt').exists);
+});
+
+test('Fingerprint', (t: ExecutionContext) => {
+  const pod = new Pod('./fixtures/static/');
+  const staticFile = pod.staticFile('/src/static/file.txt');
+  t.is(
+    staticFile.fingerprint(),
+    '7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069'
+  );
+});

--- a/src/static.ts
+++ b/src/static.ts
@@ -23,10 +23,10 @@ export class StaticFile {
     return this.pod.router.getUrl('static_dir', this);
   }
 
-  /** Returns the sha256 hash for the file. */
-  fingerprint() {
+  /** Returns the MD5 hash for the file. */
+  get fingerprint() {
     const content = this.pod.readFile(this.podPath);
-    return createHash('sha256').update(content).digest('hex');
+    return createHash('md5').update(content).digest('hex');
   }
 
   /** Returns whether the file exists. */

--- a/src/static.ts
+++ b/src/static.ts
@@ -1,5 +1,6 @@
 import {Pod} from './pod';
 import {Url} from './url';
+import {createHash} from 'crypto';
 
 export class StaticFile {
   pod: Pod;
@@ -20,5 +21,16 @@ export class StaticFile {
    */
   get url(): Url | undefined {
     return this.pod.router.getUrl('static_dir', this);
+  }
+
+  /** Returns the sha256 hash for the file. */
+  fingerprint() {
+    const content = this.pod.readFile(this.podPath);
+    return createHash('sha256').update(content).digest('hex');
+  }
+
+  /** Returns whether the file exists. */
+  get exists() {
+    return this.pod.fileExists(this.podPath);
   }
 }


### PR DESCRIPTION
Should we make `fingerprint` a getter or a callable? If a callable, we may be able to extend it (i.e. you could request the md5 instead of the default sha256). That's how Hugo works FWIW.

Also, should we make `exists` a callable (ie. `exists()`) because it has to make the fs operation?