### PR TITLE
Add pod.basePath

### DIFF
--- a/fixtures/basePath/amagaki.js
+++ b/fixtures/basePath/amagaki.js
@@ -1,0 +1,5 @@
+module.exports = function (pod) {
+  pod.configure({
+    basePath: '/foo/',
+  });
+};

--- a/fixtures/basePath/content/about.njk
+++ b/fixtures/basePath/content/about.njk
@@ -1,0 +1,5 @@
+---
+$path: /${pod.basePath}/${doc.basename}/
+$view: self
+---
+Hello World

--- a/src/fixtures.test.ts
+++ b/src/fixtures.test.ts
@@ -14,6 +14,12 @@ const fixtures = fs
 for (const fixture of fixtures) {
   test(`Build fixture: ${fixture}`, async (t: ExecutionContext) => {
     const pod = new Pod(`./fixtures/${fixture}/`);
+    if (!pod.router.routes.length) {
+      t.pass(
+        `NOTE: Skipped testing fixture ${fixture} as no routes were found.`
+      );
+      return;
+    }
     const result = await pod.builder.export();
     t.true(result.manifest.files.length > 0);
   });

--- a/src/pod.test.ts
+++ b/src/pod.test.ts
@@ -2,6 +2,15 @@ import {ExecutionContext} from 'ava';
 import {Pod} from './pod';
 import test from 'ava';
 
+test('Pod basepath', (t: ExecutionContext) => {
+  const pod = new Pod('./fixtures/basePath/');
+  t.is(pod.basePath, '/foo/');
+  // Warmup to ensure URLs are generated for docs.
+  pod.router.warmup();
+  const doc = pod.doc('/content/about.njk');
+  t.is(doc.url?.path, '/foo/about/');
+});
+
 test('Pod collection', (t: ExecutionContext) => {
   const pod = new Pod('./fixtures/simple/');
   const collection = pod.collection('/content/pages/');

--- a/src/pod.ts
+++ b/src/pod.ts
@@ -31,8 +31,9 @@ export interface MetadataConfig {
 }
 
 export interface PodConfig {
-  meta: MetadataConfig;
+  basePath?: string;
   localization?: LocalizationConfig;
+  meta: MetadataConfig;
   staticRoutes?: Array<StaticDirConfig>;
 }
 
@@ -137,6 +138,20 @@ export class Pod {
       this.router.providers['static_dir'] = [];
       this.router.addStaticDirectoryRoutes(this.config.staticRoutes);
     }
+  }
+
+  /**
+   * Returns the base URL path where the site is "mounted". This property is
+   * meant to be used in conjunction with the `$path` configuration in content.
+   *
+   * For example, if you want to generate your site to: `/mysite/`,
+   * `/mysite/about/`, `/mysite/static/main.css`, etc. You would use in
+   * `_collection.yaml`:
+   *
+   * $path: /${pod.basePath}/${doc.basename}/
+   */
+  get basePath() {
+    return this.config?.basePath;
   }
 
   /**

--- a/src/router.ts
+++ b/src/router.ts
@@ -26,7 +26,9 @@ export class Router {
       // Default static routes. This can be overridden by the presence of any
       // static routes configured in `amagaki.js`.
       new StaticDirectoryRouteProvider(this, {
-        path: '/static/',
+        path: this.pod.basePath
+          ? `${cleanBasePath(this.pod.basePath)}/static/`
+          : '/static/',
         staticDir: '/src/static/',
       }),
     ].forEach(provider => {
@@ -34,10 +36,12 @@ export class Router {
     });
   }
 
-  createTree() {}
-
   resolve(path: string): Route | null {
-    // TODO: Implement route trie.
+    // NOTE: Instead of using a route trie with placeholders, and resolving
+    // request paths against that tree, we currently generate all concrete
+    // routes, and match request paths to the concrete URLs. If this does not
+    // prove to be a robust solution, this approach can be replaced with a route
+    // trie and matching abstract routes.
     for (let i = 0; i < this.routes.length; i++) {
       const route = this.routes[i];
       if (route.url.path === path) {
@@ -306,6 +310,7 @@ export class DocumentRoute extends Route {
     }
     urlPath = utils.interpolate(this.pod, this.doc.pathFormat, {
       doc: this.doc,
+      pod: this.pod,
     }) as string;
 
     // Clean up repeated slashes.


### PR DESCRIPTION
Work on #49

NOTE: This is currently implemented as `pod.basePath` so it's convenient for use in the `_collection.yaml` and `$path` settings. LMK if you think we should nest this somewhere else.

This also updates the fixture test runner to skip empty directories (that might get left in a git workspace when switching branches).