### PR TITLE
Implement updated YAML types

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ A few proposed naming changes (TBD?):
 
 - `_blueprint.yaml` is now `_collection.yaml`
 - `podspec.yaml` is now `amagaki.yaml`
-- `!g.doc`, `!g.static`, `!g.yaml`, etc. are now `!a.Doc`, `!a.Static`, `!a.Content`
-- `!g.string` is now `!a.String` which is similar but has more features
+- `!g.doc`, `!g.static`, `!g.yaml`, etc. are now `!pod.doc`, `!pod.staticFile`, `!a.Content`
+- `!g.string` is now `!pod.string` which is similar but has more features
 - `.grow/index.proto.json` is now `.amagaki/build.json` (the `files`, `commit`, and `branch` values are preserved. the `deployed` key is changed to `built` and the `author` key is removed as it is a duplicate of the `commit.author` value)
 
 ## Benchmarks

--- a/example/content/pages/about.yaml
+++ b/example/content/pages/about.yaml
@@ -4,4 +4,4 @@ partials:
   title: Here's a picture of a cat
   body: Sunt elit et aute commodo id. Esse quis cupidatat reprehenderit qui eiusmod sit proident sit tempor aliquip eu. Irure reprehenderit magna duis mollit nostrud aute dolore nulla adipisicing nisi. Excepteur sunt sint duis do proident do nulla veniam incididunt magna velit eiusmod sunt occaecat.
   images:
-  - static: !a.Static /src/static/images/cat.jpg
+  - static: !pod.staticFile /src/static/images/cat.jpg

--- a/example/content/pages/index.yaml
+++ b/example/content/pages/index.yaml
@@ -5,7 +5,7 @@ title: Home
 description: Page description
 partials:
 - partial: hero
-  title: !a.String
+  title: !pod.string
     prefer: Welcome to Amagaki
     value: Welcome to Amagaki
   body: !a.IfEnvironment

--- a/example/content/pages/index.yaml
+++ b/example/content/pages/index.yaml
@@ -8,7 +8,7 @@ partials:
   title: !pod.string
     prefer: Welcome to Amagaki
     value: Welcome to Amagaki
-  body: !a.IfEnvironment
+  body: !IfEnvironment
     default: Default body content. Pariatur excepteur sit mollit cupidatat deserunt exercitation sit do minim voluptate. Fugiat anim est duis.
     prod: Prod body content. Ex aute eu aliquip voluptate. Officia amet voluptate aliquip cillum aliqua aliquip voluptate labore sunt.
   buttons:

--- a/example/content/pages/routes.yaml
+++ b/example/content/pages/routes.yaml
@@ -2,9 +2,9 @@ title: All routes
 description: Page description
 partials:
 - partial: hero
-  title: !a.String
+  title: !pod.string
     value: Routes
-  body: !a.String
+  body: !pod.string
     value: Browse all the routes below.
 - partial: spacer
   options:

--- a/example/content/partials/header.yaml
+++ b/example/content/partials/header.yaml
@@ -1,7 +1,7 @@
 partial: header
 logo:
   doc: !pod.doc /content/pages/index.yaml
-  title: !a.Yaml /content/partials/base.yaml?title
+  title: !pod.yaml /content/partials/base.yaml?title
   image:
     url: https://placeholder-dot-madebygoog.appspot.com/7x3.svg
 nav:

--- a/example/content/partials/header.yaml
+++ b/example/content/partials/header.yaml
@@ -1,12 +1,12 @@
 partial: header
 logo:
-  doc: !a.Doc /content/pages/index.yaml
+  doc: !pod.doc /content/pages/index.yaml
   title: !a.Yaml /content/partials/base.yaml?title
   image:
     url: https://placeholder-dot-madebygoog.appspot.com/7x3.svg
 nav:
-- !a.Doc /content/pages/index.yaml
-- !a.Doc /content/pages/routes.yaml
-- !a.Doc /content/pages/about.yaml
-- !a.Doc /content/pages/bio.md
-- !a.Doc /content/pages/contact.yaml
+- !pod.doc /content/pages/index.yaml
+- !pod.doc /content/pages/routes.yaml
+- !pod.doc /content/pages/about.yaml
+- !pod.doc /content/pages/bio.md
+- !pod.doc /content/pages/contact.yaml

--- a/example/views/base.njk
+++ b/example/views/base.njk
@@ -3,8 +3,8 @@
 <title>{{doc.fields.title}}</title>
 <meta name="description" value="{{doc.fields.description}}">
 <link href="//fonts.googleapis.com/css?family=Nunito&amp;display=swap" rel="stylesheet" type="text/css">
-<link rel="stylesheet" href="{{a.static('/dist/css/main.css').url.path}}">
-<script src="{{a.static('/dist/js/main.js').url.path}}"></script>
+<link rel="stylesheet" href="{{pod.staticFile('/dist/css/main.css').url.path}}">
+<script src="{{pod.staticFile('/dist/js/main.js').url.path}}"></script>
 <body>
 <div class="main">
     {% set partial = pod.doc('/content/partials/header.yaml').fields %}

--- a/fixtures/simple/content/pages/about.yaml
+++ b/fixtures/simple/content/pages/about.yaml
@@ -4,4 +4,4 @@ partials:
   title: Here's a picture of a cat
   body: Sunt elit et aute commodo id. Esse quis cupidatat reprehenderit qui eiusmod sit proident sit tempor aliquip eu. Irure reprehenderit magna duis mollit nostrud aute dolore nulla adipisicing nisi. Excepteur sunt sint duis do proident do nulla veniam incididunt magna velit eiusmod sunt occaecat.
   images:
-  - static: !a.Static /src/static/images/cat.jpg
+  - static: !pod.staticFile /src/static/images/cat.jpg

--- a/fixtures/simple/content/pages/index.yaml
+++ b/fixtures/simple/content/pages/index.yaml
@@ -5,7 +5,7 @@ title: Home
 description: Page description
 partials:
 - partial: hero
-  title: !a.String
+  title: !pod.string
     prefer: Welcome to Amagaki
     value: Welcome to Amagaki
   body: !a.IfEnvironment

--- a/fixtures/simple/content/pages/index.yaml
+++ b/fixtures/simple/content/pages/index.yaml
@@ -8,7 +8,7 @@ partials:
   title: !pod.string
     prefer: Welcome to Amagaki
     value: Welcome to Amagaki
-  body: !a.IfEnvironment
+  body: !IfEnvironment
     default: Default body content. Pariatur excepteur sit mollit cupidatat deserunt exercitation sit do minim voluptate. Fugiat anim est duis.
     prod: Prod body content. Ex aute eu aliquip voluptate. Officia amet voluptate aliquip cillum aliqua aliquip voluptate labore sunt.
   buttons:

--- a/fixtures/simple/content/pages/routes.yaml
+++ b/fixtures/simple/content/pages/routes.yaml
@@ -2,9 +2,9 @@ title: All routes
 description: Page description
 partials:
 - partial: hero
-  title: !a.String
+  title: !pod.string
     value: Routes
-  body: !a.String
+  body: !pod.string
     value: Browse all the routes below.
 - partial: spacer
   options:

--- a/fixtures/simple/content/partials/header.yaml
+++ b/fixtures/simple/content/partials/header.yaml
@@ -1,7 +1,7 @@
 partial: header
 logo:
   doc: !pod.doc /content/pages/index.yaml
-  title: !a.Yaml /content/partials/base.yaml?title
+  title: !pod.yaml /content/partials/base.yaml?title
   image:
     url: https://placeholder-dot-madebygoog.appspot.com/7x3.svg
 nav:

--- a/fixtures/simple/content/partials/header.yaml
+++ b/fixtures/simple/content/partials/header.yaml
@@ -1,12 +1,12 @@
 partial: header
 logo:
-  doc: !a.Doc /content/pages/index.yaml
+  doc: !pod.doc /content/pages/index.yaml
   title: !a.Yaml /content/partials/base.yaml?title
   image:
     url: https://placeholder-dot-madebygoog.appspot.com/7x3.svg
 nav:
-- !a.Doc /content/pages/index.yaml
-- !a.Doc /content/pages/routes.yaml
-- !a.Doc /content/pages/about.yaml
-- !a.Doc /content/pages/bio.md
-- !a.Doc /content/pages/contact.yaml
+- !pod.doc /content/pages/index.yaml
+- !pod.doc /content/pages/routes.yaml
+- !pod.doc /content/pages/about.yaml
+- !pod.doc /content/pages/bio.md
+- !pod.doc /content/pages/contact.yaml

--- a/fixtures/simple/views/base.njk
+++ b/fixtures/simple/views/base.njk
@@ -3,8 +3,8 @@
 <title>{{doc.fields.title}}</title>
 <meta name="description" value="{{doc.fields.description}}">
 <link href="//fonts.googleapis.com/css?family=Nunito&amp;display=swap" rel="stylesheet" type="text/css">
-<link rel="stylesheet" href="{{a.static('/dist/css/main.css').url.path}}">
-<script src="{{a.static('/dist/js/main.js').url.path}}"></script>
+<link rel="stylesheet" href="{{pod.staticFile('/dist/css/main.css').url.path}}">
+<script src="{{pod.staticFile('/dist/js/main.js').url.path}}"></script>
 <body>
 <div class="main">
     {% set partial = pod.doc('/content/partials/header.yaml').fields %}

--- a/fixtures/yamlTypes/amagaki.js
+++ b/fixtures/yamlTypes/amagaki.js
@@ -1,0 +1,8 @@
+module.exports = function (pod) {
+  pod.configure({
+    environments: {
+      default: {},
+      prod: {},
+    },
+  });
+};

--- a/fixtures/yamlTypes/content/index.yaml
+++ b/fixtures/yamlTypes/content/index.yaml
@@ -1,0 +1,3 @@
+button:
+  doc: !pod.doc /content/pages/index.yaml
+  docs: !pod.doc [/content/pages/index.yaml, {foo: bar}]

--- a/fixtures/yamlTypes/content/index.yaml
+++ b/fixtures/yamlTypes/content/index.yaml
@@ -1,3 +1,0 @@
-button:
-  doc: !pod.doc /content/pages/index.yaml
-  docs: !pod.doc [/content/pages/index.yaml, {foo: bar}]

--- a/fixtures/yamlTypes/content/pages/index.yaml
+++ b/fixtures/yamlTypes/content/pages/index.yaml
@@ -1,24 +1,24 @@
 doc:
-  simple: !pod.doc /content/pages/index.yaml
-  options: !pod.doc [/content/pages/index.yaml, !pod.locale 'de']
+  simple: !pod.doc '/content/pages/index.yaml'
+  options: !pod.doc ['/content/pages/index.yaml', !pod.locale 'de']
 docs:
-  simple: !pod.docs [/content/pages/index.yaml, '/content/posts/2019-01-06.md']
+  simple: !pod.docs ['/content/pages/index.yaml', '/content/posts/2019-01-06.md']
   options1: !pod.docs ['/content/posts/**', {sort: 'order'}]
   options2: !pod.docs [['/content/posts/**'], {sort: 'order'}]
-collection: !pod.collection /content/pages/
+collection: !pod.collection '/content/pages/'
 collections:
-  simple: !pod.collections [/content/pages/, /content/posts/]
-  options1: !pod.collections [/content/pages/, {sort: 'order'}]
-  options2: !pod.collections [[/content/pages/, /content/posts/], {sort: 'order'}]
+  simple: !pod.collections ['/content/pages/', '/content/posts/']
+  options1: !pod.collections ['/content/pages/', {sort: 'order'}]
+  options2: !pod.collections [['/content/pages/', '/content/posts/'], {sort: 'order'}]
 locale: !pod.locale 'de'
 locales: !pod.locales ['de', 'ja']
-staticFile: !pod.staticFile /src/static/file.txt
+staticFile: !pod.staticFile '/src/static/file.txt'
 string:
-  simple: !pod.string Hello World
+  simple: !pod.string 'Hello World'
   options: !pod.string
-    prefer: New Value
-    value: Old Value
+    prefer: 'New Value'
+    value: 'Old Value'
 yaml: !pod.yaml /content/pages/page.yaml
 IfEnvironment: !IfEnvironment
-  default: 'foo'
-  prod: 'bar'
+  default: 'Default Value'
+  prod: 'Prod Value'

--- a/fixtures/yamlTypes/content/pages/index.yaml
+++ b/fixtures/yamlTypes/content/pages/index.yaml
@@ -1,9 +1,15 @@
-doc: !pod.doc /content/pages/index.yaml
-docWithOptions: !pod.doc [/content/pages/index.yaml, !pod.locale 'de']
+doc:
+  simple: !pod.doc /content/pages/index.yaml
+  options: !pod.doc [/content/pages/index.yaml, !pod.locale 'de']
 docs: !pod.docs [/content/pages/index.yaml, /content/posts/2019-01-06.md]
 collection: !pod.collection /content/pages/
 collections: !pod.collections [/content/pages/, /content/posts/]
 locale: !pod.locale 'de'
 locales: !pod.locales ['de', 'ja']
-yaml: !pod.yaml /content/pages/page.yaml
 staticFile: !pod.staticFile /src/static/file.txt
+string:
+  simple: !pod.string Hello World
+  options: !pod.string
+    prefer: New Value
+    value: Old Value
+yaml: !pod.yaml /content/pages/page.yaml

--- a/fixtures/yamlTypes/content/pages/index.yaml
+++ b/fixtures/yamlTypes/content/pages/index.yaml
@@ -3,9 +3,13 @@ doc:
   options: !pod.doc [/content/pages/index.yaml, !pod.locale 'de']
 docs:
   simple: !pod.docs [/content/pages/index.yaml, '/content/posts/2019-01-06.md']
-  options: !pod.docs ['/content/posts/**', {'sort': 'order'}]
+  options1: !pod.docs ['/content/posts/**', {sort: 'order'}]
+  options2: !pod.docs [['/content/posts/**'], {sort: 'order'}]
 collection: !pod.collection /content/pages/
-collections: !pod.collections [/content/pages/, /content/posts/]
+collections:
+  simple: !pod.collections [/content/pages/, /content/posts/]
+  options1: !pod.collections [/content/pages/, {sort: 'order'}]
+  options2: !pod.collections [[/content/pages/, /content/posts/], {sort: 'order'}]
 locale: !pod.locale 'de'
 locales: !pod.locales ['de', 'ja']
 staticFile: !pod.staticFile /src/static/file.txt

--- a/fixtures/yamlTypes/content/pages/index.yaml
+++ b/fixtures/yamlTypes/content/pages/index.yaml
@@ -1,0 +1,9 @@
+doc: !pod.doc /content/pages/index.yaml
+docWithOptions: !pod.doc [/content/pages/index.yaml, !pod.locale 'de']
+docs: !pod.docs [/content/pages/index.yaml, /content/posts/2019-01-06.md]
+collection: !pod.collection /content/pages/
+collections: !pod.collections [/content/pages/, /content/posts/]
+locale: !pod.locale 'de'
+locales: !pod.locales ['de', 'ja']
+yaml: !pod.yaml /content/pages/page.yaml
+staticFile: !pod.staticFile /src/static/file.txt

--- a/fixtures/yamlTypes/content/pages/index.yaml
+++ b/fixtures/yamlTypes/content/pages/index.yaml
@@ -1,7 +1,9 @@
 doc:
   simple: !pod.doc /content/pages/index.yaml
   options: !pod.doc [/content/pages/index.yaml, !pod.locale 'de']
-docs: !pod.docs [/content/pages/index.yaml, /content/posts/2019-01-06.md]
+docs:
+  simple: !pod.docs [/content/pages/index.yaml, '/content/posts/2019-01-06.md']
+  options: !pod.docs ['/content/posts/**', {'sort': 'order'}]
 collection: !pod.collection /content/pages/
 collections: !pod.collections [/content/pages/, /content/posts/]
 locale: !pod.locale 'de'

--- a/fixtures/yamlTypes/content/pages/index.yaml
+++ b/fixtures/yamlTypes/content/pages/index.yaml
@@ -13,3 +13,6 @@ string:
     prefer: New Value
     value: Old Value
 yaml: !pod.yaml /content/pages/page.yaml
+IfEnvironment: !IfEnvironment
+  default: 'foo'
+  prod: 'bar'

--- a/fixtures/yamlTypes/content/pages/index.yaml
+++ b/fixtures/yamlTypes/content/pages/index.yaml
@@ -18,7 +18,10 @@ string:
   options: !pod.string
     prefer: 'New Value'
     value: 'Old Value'
-yaml: !pod.yaml /content/pages/page.yaml
+yaml:
+  simple: !pod.yaml /content/pages/page.yaml
+  deep1: !pod.yaml /content/pages/page.yaml?key1
+  deep2: !pod.yaml /content/pages/page.yaml?key2.key3
 IfEnvironment: !IfEnvironment
   default: 'Default Value'
   prod: 'Prod Value'

--- a/fixtures/yamlTypes/content/pages/page.yaml
+++ b/fixtures/yamlTypes/content/pages/page.yaml
@@ -1,0 +1,3 @@
+key1: value1
+key2:
+  key3: value3

--- a/fixtures/yamlTypes/content/posts/2019-01-06.md
+++ b/fixtures/yamlTypes/content/posts/2019-01-06.md
@@ -1,0 +1,4 @@
+---
+order: 2
+---
+Hello World

--- a/fixtures/yamlTypes/content/posts/2021-08-08.md
+++ b/fixtures/yamlTypes/content/posts/2021-08-08.md
@@ -1,0 +1,1 @@
+# Hello World!

--- a/fixtures/yamlTypes/content/posts/2021-08-08.md
+++ b/fixtures/yamlTypes/content/posts/2021-08-08.md
@@ -1,1 +1,4 @@
-# Hello World!
+---
+order: 1
+---
+Hello World

--- a/fixtures/yamlTypes/src/static/file.txt
+++ b/fixtures/yamlTypes/src/static/file.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
       "ts"
     ],
     "files": [
-      "src/*.test.ts"
+      "src/*.test.ts",
+      "src/**/*.test.ts"
     ]
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
       "ts"
     ],
     "files": [
-      "src/*.test.ts",
       "src/**/*.test.ts"
     ]
   },

--- a/src/document.ts
+++ b/src/document.ts
@@ -46,7 +46,7 @@ export interface DocumentListOptions {
  * own document object (documents are instantiated with both a `podPath` and a
  * `locale` parameter). If a `locale` parameter is not provided, the pod's
  * default locale is used to instantiate the document. Localized documents will
- * automatically resolve any localizable elements (such as `!a.String` YAML
+ * automatically resolve any localizable elements (such as `!pod.string` YAML
  * types or `!a.Localized` YAML types) to their correct locale.
  *
  * Finally, documents may or may not actually be bound to routes. In other

--- a/src/plugins/yaml.test.ts
+++ b/src/plugins/yaml.test.ts
@@ -30,4 +30,16 @@ test('Inbuilt YAML types', (t: ExecutionContext) => {
     pod.string({prefer: 'New Value', value: 'Old Value'})
   );
   t.deepEqual(doc.fields.yaml, pod.readYaml('/content/pages/page.yaml'));
+  t.deepEqual(doc.fields.IfEnvironment, 'foo');
+});
+
+test('IfEnvironment', (t: ExecutionContext) => {
+  const pod = new Pod('./fixtures/yamlTypes/', {
+    dev: false,
+    host: 'example.com',
+    name: 'prod',
+    scheme: 'https',
+  });
+  const doc = pod.doc('/content/pages/index.yaml') as Document;
+  t.deepEqual(doc.fields.IfEnvironment, 'bar');
 });

--- a/src/plugins/yaml.test.ts
+++ b/src/plugins/yaml.test.ts
@@ -17,13 +17,25 @@ test('Inbuilt YAML types', (t: ExecutionContext) => {
     pod.docs(['/content/pages/index.yaml', '/content/posts/2019-01-06.md'])
   );
   t.deepEqual(
-    doc.fields.docs.options,
+    doc.fields.docs.options1,
+    pod.docs(['/content/posts/**'], {sort: 'order'})
+  );
+  t.deepEqual(
+    doc.fields.docs.options2,
     pod.docs(['/content/posts/**'], {sort: 'order'})
   );
   t.deepEqual(doc.fields.collection, pod.collection('/content/pages/'));
   t.deepEqual(
-    doc.fields.collections,
+    doc.fields.collections.simple,
     pod.docs(['/content/pages/', '/content/posts/'])
+  );
+  t.deepEqual(
+    doc.fields.collections.options1,
+    pod.docs(['/content/pages/'], {sort: 'order'})
+  );
+  t.deepEqual(
+    doc.fields.collections.options2,
+    pod.docs(['/content/pages/', '/content/posts/'], {sort: 'order'})
   );
   t.deepEqual(doc.fields.locale, pod.locale('de'));
   t.deepEqual(doc.fields.locales, LocaleSet.fromIds(['de', 'ja'], pod));

--- a/src/plugins/yaml.test.ts
+++ b/src/plugins/yaml.test.ts
@@ -45,7 +45,9 @@ test('Inbuilt YAML types', (t: ExecutionContext) => {
     doc.fields.string.options,
     pod.string({prefer: 'New Value', value: 'Old Value'})
   );
-  t.deepEqual(doc.fields.yaml, pod.readYaml('/content/pages/page.yaml'));
+  t.deepEqual(doc.fields.yaml.simple, pod.readYaml('/content/pages/page.yaml'));
+  t.deepEqual(doc.fields.yaml.deep1, 'value1');
+  t.deepEqual(doc.fields.yaml.deep2, 'value3');
   t.deepEqual(doc.fields.IfEnvironment, 'Default Value');
 });
 

--- a/src/plugins/yaml.test.ts
+++ b/src/plugins/yaml.test.ts
@@ -13,8 +13,12 @@ test('Inbuilt YAML types', (t: ExecutionContext) => {
     pod.doc('/content/pages/index.yaml', pod.locale('de'))
   );
   t.deepEqual(
-    doc.fields.docs,
+    doc.fields.docs.simple,
     pod.docs(['/content/pages/index.yaml', '/content/posts/2019-01-06.md'])
+  );
+  t.deepEqual(
+    doc.fields.docs.options,
+    pod.docs(['/content/posts/**'], {sort: 'order'})
   );
   t.deepEqual(doc.fields.collection, pod.collection('/content/pages/'));
   t.deepEqual(

--- a/src/plugins/yaml.test.ts
+++ b/src/plugins/yaml.test.ts
@@ -1,0 +1,33 @@
+import {Document} from '../document';
+import {ExecutionContext} from 'ava';
+import {LocaleSet} from '../locale';
+import {Pod} from '../pod';
+import test from 'ava';
+
+test('Inbuilt YAML types', (t: ExecutionContext) => {
+  const pod = new Pod('./fixtures/yamlTypes/');
+  const doc = pod.doc('/content/pages/index.yaml') as Document;
+  t.deepEqual(doc.fields.doc.simple, pod.doc('/content/pages/index.yaml'));
+  t.deepEqual(
+    doc.fields.doc.options,
+    pod.doc('/content/pages/index.yaml', pod.locale('de'))
+  );
+  t.deepEqual(
+    doc.fields.docs,
+    pod.docs(['/content/pages/index.yaml', '/content/posts/2019-01-06.md'])
+  );
+  t.deepEqual(doc.fields.collection, pod.collection('/content/pages/'));
+  t.deepEqual(
+    doc.fields.collections,
+    pod.docs(['/content/pages/', '/content/posts/'])
+  );
+  t.deepEqual(doc.fields.locale, pod.locale('de'));
+  t.deepEqual(doc.fields.locales, LocaleSet.fromIds(['de', 'ja'], pod));
+  t.deepEqual(doc.fields.staticFile, pod.staticFile('/src/static/file.txt'));
+  t.deepEqual(doc.fields.string.simple, pod.string({value: 'Hello World'}));
+  t.deepEqual(
+    doc.fields.string.options,
+    pod.string({prefer: 'New Value', value: 'Old Value'})
+  );
+  t.deepEqual(doc.fields.yaml, pod.readYaml('/content/pages/page.yaml'));
+});

--- a/src/plugins/yaml.test.ts
+++ b/src/plugins/yaml.test.ts
@@ -46,7 +46,7 @@ test('Inbuilt YAML types', (t: ExecutionContext) => {
     pod.string({prefer: 'New Value', value: 'Old Value'})
   );
   t.deepEqual(doc.fields.yaml, pod.readYaml('/content/pages/page.yaml'));
-  t.deepEqual(doc.fields.IfEnvironment, 'foo');
+  t.deepEqual(doc.fields.IfEnvironment, 'Default Value');
 });
 
 test('IfEnvironment', (t: ExecutionContext) => {
@@ -57,5 +57,5 @@ test('IfEnvironment', (t: ExecutionContext) => {
     scheme: 'https',
   });
   const doc = pod.doc('/content/pages/index.yaml') as Document;
-  t.deepEqual(doc.fields.IfEnvironment, 'bar');
+  t.deepEqual(doc.fields.IfEnvironment, 'Prod Value');
 });

--- a/src/plugins/yaml.ts
+++ b/src/plugins/yaml.ts
@@ -286,8 +286,11 @@ export class YamlPlugin implements PluginComponent {
       })
     );
 
+    /**
+     * !IfEnvironment {default: 'foo', prod: 'bar'}
+     */
     yamlTypeManager.addType(
-      new yaml.Type('!a.IfEnvironment', {
+      new yaml.Type('!IfEnvironment', {
         kind: 'mapping',
         resolve: data => {
           return typeof data === 'object';

--- a/src/plugins/yaml.ts
+++ b/src/plugins/yaml.ts
@@ -220,7 +220,7 @@ export class YamlPlugin implements PluginComponent {
           return typeof data === 'string';
         },
         construct: value => {
-          return this.pod.string(value);
+          return this.pod.string({value: value});
         },
         represent: value => {
           const string = value as TranslationString;

--- a/src/plugins/yaml.ts
+++ b/src/plugins/yaml.ts
@@ -30,7 +30,11 @@ export class YamlPlugin implements PluginComponent {
   }
 
   /**
-   * Returns whether supplied parts resemble the arguments for `pod.docs` or `pod.collections`.
+   * Returns whether supplied parts resemble the arguments for `pod.docs` or
+   * `pod.collections`. Supplied parts must be in the following format:
+   * ```
+   * patterns?: string[] | string, options?: DocumentListOptions
+   * ```
    */
   private partsLikeGlobOptions(parts: any) {
     return (

--- a/website/content/index.yaml
+++ b/website/content/index.yaml
@@ -10,10 +10,10 @@ partials:
     url: https://lh3.googleusercontent.com/XmOO56dH01rI5j1WdSfzK8i_O06BaylF28vP-6diaRblzW5jtEMuh_1oHNvSBJsqaF5I-R3oa8fIOsOEePt-wrSZtDoxnol6p3M=w1024
   buttons:
   - label: Read manual
-    doc: !a.Doc /content/docs/index.md
+    doc: !pod.doc /content/docs/index.md
     left_icon: menu_book
   - label: Explore the starter
-    doc: !a.Doc /content/docs/index.md
+    doc: !pod.doc /content/docs/index.md
     class: button--low
     left_icon: explore
 

--- a/website/content/partials/footer.yaml
+++ b/website/content/partials/footer.yaml
@@ -2,11 +2,11 @@ partial: footer
 menu:
 - url: ${pod.config.metadata.githubEditRoot}${doc.podPath}
   title: Edit this page
-- doc: !a.Doc /content/docs/index.md
+- doc: !pod.doc /content/docs/index.md
   title: Manual
 - url: /api/
   title: API Reference
-- doc: !a.Doc /content/benchmarks.md
+- doc: !pod.doc /content/benchmarks.md
   title: Benchmarks
-- doc: !a.Doc /content/accessibility.md
+- doc: !pod.doc /content/accessibility.md
   title: Accessibility

--- a/website/content/partials/header.yaml
+++ b/website/content/partials/header.yaml
@@ -1,15 +1,15 @@
 partial: header
 logo:
-  home: !a.Doc /content/index.yaml
+  home: !pod.doc /content/index.yaml
   image:
     url: https://lh3.googleusercontent.com/XmOO56dH01rI5j1WdSfzK8i_O06BaylF28vP-6diaRblzW5jtEMuh_1oHNvSBJsqaF5I-R3oa8fIOsOEePt-wrSZtDoxnol6p3M=w96
   title: Amagaki
 menu:
-- doc: !a.Doc /content/index.yaml
+- doc: !pod.doc /content/index.yaml
   title: Home
-- doc: !a.Doc /content/docs/index.md
+- doc: !pod.doc /content/docs/index.md
   title: Docs
-- doc: !a.Doc /content/api.yaml
+- doc: !pod.doc /content/api.yaml
   title: API Reference
 aside:
   githubProject: blinkkcode/amagaki


### PR DESCRIPTION
This PR updates the syntax around Amagaki to be consistent (or, as close to as consistent and useful as possible), by cementing a concept called "pod functions".

"Pod functions" are basically the usage of (what we'll call) the "Pod API" – all the directly callable, useful functions on the primary "pod" object.

I think this concept is generally accessible (by way of docs), and readable, and more understandable than our historical concepts of `!g.doc` (and similar) in templates and YAML files in Grow. Since the syntax is as close as possible to directly calling the function on the main pod object, usage should be understandable across all parts of Grow.

In this PR I implement all the YAML types for the pod functions outlined here: 
https://blinkkcode.github.io/amagaki/docs/content-management/yaml-types/

(except for `!pod.metadata` and `!pod.config` which may require further thought/design)

In this PR I also suggest eliminating the prefix from the conditional YAML types (currently, `IfEnvironment`) just out of clarity.

While there's a bunch of cleanup code here the best way to understand the design/intent of this PR is to look at the fixture:  
https://github.com/blinkkcode/amagaki/compare/feature/yaml-type-cleanup?expand=1#diff-b9b613b20f82502b33c8ca895e5dc52e9387c26e7a7a0a9dc4579933043aee49

With this PR we standardize how devs interact with pods throughout TS/JS, YAML, and templates.

```
# In templates:
{{pod.doc('/content/pages/index.yaml')}}

# In YAML:
foo: !pod.doc /content/pages/index.yaml

# In JavaScript:
pod.doc('/content/pages/index.yaml')
```

And we call these "pod functions" in docs, chat, etc. :)