### PR TITLE
Add option to `serve` command for port.

### DIFF
--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -9,6 +9,7 @@ import {createApp} from '../server';
 interface ServeOptions {
   fcd?: string;
   ref?: string;
+  port?: number;
   site: string;
 }
 
@@ -22,12 +23,12 @@ export class ServeCommand {
   }
 
   async run(path = './') {
-    const port = process.env.PORT || '8080';
+    const port = this.options.port || process.env.PORT || 8080;
     const pod = new Pod(fs.realpathSync(path), {
       dev: true,
       host: 'localhost',
       name: 'default',
-      port: port,
+      port: `${port}`,
       scheme: 'http',
     });
     if (this.globalOptions.env) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ program
 program
   .command('serve [root]')
   .description('start the development server')
+  .option('--port <number>', 'development server port', '8080')
   .action((path, options) => {
     if (!isNodeVersionSupported()) {
       return;


### PR DESCRIPTION
Allows for `amagaki server --port 8888` ability for providing a port for the server to run on.

Help shows as:

```
Options:
  --port <number>  development server port (default: "8080")
```